### PR TITLE
Remove `#![feature(unboxed_closures)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@
 
 //! Minimal UI library based on GTK+.
 
-#![feature(unboxed_closures)]
 #![warn(
     trivial_casts,
     trivial_numeric_casts,


### PR DESCRIPTION
This feature is currently not used and blocks building with stable rust.