### PR TITLE
Fix/compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 sudo: false
 language: rust
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,13 @@ before_script:
       pip install 'travis-cargo<0.2' --user &&
       export PATH=$HOME/.local/bin:$PATH
 
-# script:
-#   - |
-#       travis-cargo build &&
-#       travis-cargo test
 script:
   - |
       travis-cargo build
 
-      after_success:
-  - travis-cargo coveralls --no-sudo --verify
-  - ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/lib-*
+# after_success:
+#   - travis-cargo coveralls --no-sudo --verify
+#   - ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/lib-*
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ before_script:
       pip install 'travis-cargo<0.2' --user &&
       export PATH=$HOME/.local/bin:$PATH
 
+# script:
+#   - |
+#       travis-cargo build &&
+#       travis-cargo test
 script:
   - |
-      travis-cargo build &&
-      travis-cargo test
-after_success:
+      travis-cargo build
+
+      after_success:
   - travis-cargo coveralls --no-sudo --verify
   - ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/lib-*
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -27,7 +27,6 @@ extern crate mg_settings;
 #[macro_use]
 extern crate mg_settings_macros;
 extern crate pretty_env_logger;
-#[macro_use]
 extern crate relm;
 #[macro_use]
 extern crate relm_derive;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -24,7 +24,6 @@ extern crate mg;
 extern crate mg_settings;
 #[macro_use]
 extern crate mg_settings_macros;
-#[macro_use]
 extern crate relm;
 #[macro_use]
 extern crate relm_derive;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,8 +19,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#![feature(use_extern_macros)]
-
 extern crate gtk;
 extern crate mg;
 extern crate mg_settings;

--- a/src/app/keypress.rs
+++ b/src/app/keypress.rs
@@ -20,7 +20,6 @@
  */
 
 use std::cell::Cell;
-use std::char;
 use std::rc::Rc;
 
 use gdk::EventKey;

--- a/src/app/shortcut.rs
+++ b/src/app/shortcut.rs
@@ -22,7 +22,7 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use gdk::{EventKey, ModifierType, keyval_to_unicode};
+use gdk::{EventKey, ModifierType};
 use gdk::keys::constants::{Escape, Tab, ISO_Left_Tab};
 use gtk::{Inhibit, LabelExt};
 use mg_settings::{self, EnumFromStr, EnumMetaData, SettingCompletion, SpecialCommand};

--- a/src/app/status_bar.rs
+++ b/src/app/status_bar.rs
@@ -357,12 +357,12 @@ impl StatusBar {
         }
     }
 }
-
 #[derive(Msg)]
+#[allow(unused_doc_comments)]
 pub enum ItemMsg {
-    // Set the color of the status bar item.
+    /// Set the color of the status bar item.
     Color(Option<RGBA>),
-    // Set the text of the status bar item.
+    /// Set the text of the status bar item.
     Text(String),
 }
 

--- a/src/app/status_bar.rs
+++ b/src/app/status_bar.rs
@@ -358,7 +358,6 @@ impl StatusBar {
     }
 }
 #[derive(Msg)]
-#[allow(unused_doc_comments)]
 pub enum ItemMsg {
     /// Set the color of the status bar item.
     Color(Option<RGBA>),

--- a/src/app/status_bar.rs
+++ b/src/app/status_bar.rs
@@ -357,6 +357,7 @@ impl StatusBar {
         }
     }
 }
+
 #[derive(Msg)]
 pub enum ItemMsg {
     /// Set the color of the status bar item.

--- a/src/app/status_bar.rs
+++ b/src/app/status_bar.rs
@@ -360,9 +360,9 @@ impl StatusBar {
 
 #[derive(Msg)]
 pub enum ItemMsg {
-    /// Set the color of the status bar item.
+    // Set the color of the status bar item.
     Color(Option<RGBA>),
-    /// Set the text of the status bar item.
+    // Set the text of the status bar item.
     Text(String),
 }
 


### PR DESCRIPTION
This commit fix all compiler warnings except the CSS related ones.
This fixes also https://github.com/antoyo/relm/issues/247 IMO it's mg related so the relm issue can be closed I think.